### PR TITLE
add: long term statistic to water_temperature sensor

### DIFF
--- a/custom_components/new_bestway_spa/sensor.py
+++ b/custom_components/new_bestway_spa/sensor.py
@@ -32,6 +32,11 @@ class BestwaySpaSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{title.lower().replace(' ', '_')}_{key}"
         self._attr_native_unit_of_measurement = unit
 
+        # enable long-term statistics for water temperature
+        if self._key == "water_temperature":
+            self._attr_device_class = "temperature"
+            self._attr_state_class = "measurement"
+
     @property
     def native_value(self):
         if self._key == "temperature_unit":


### PR DESCRIPTION
add long term statistics to water_temperature sensor, so you can visualize historical temperature in dashboards