### PR TITLE
Convert temperature units between API and HA

### DIFF
--- a/custom_components/new_bestway_spa/climate.py
+++ b/custom_components/new_bestway_spa/climate.py
@@ -1,3 +1,4 @@
+from homeassistant.const import UnitOfTemperature
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -25,9 +26,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class BestwaySpaThermostat(CoordinatorEntity, ClimateEntity):
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
-    _attr_temperature_unit = "°C"
-    _attr_min_temp = 20
-    _attr_max_temp = 40
 
     def __init__(self, coordinator, api, title, device_id, hass):
         super().__init__(coordinator)
@@ -54,6 +52,21 @@ class BestwaySpaThermostat(CoordinatorEntity, ClimateEntity):
     @property
     def target_temperature(self):
         return self.coordinator.data.get("temperature_setting")
+
+    @property
+    def temperature_unit(self):
+        unit_code = self.coordinator.data.get("temperature_unit", 1)
+        return UnitOfTemperature.FAHRENHEIT if unit_code == 0 else UnitOfTemperature.CELSIUS
+
+    @property
+    def min_temp(self):
+        unit_code = self.coordinator.data.get("temperature_unit", 1)
+        return 68 if unit_code == 0 else 20
+    
+    @property
+    def max_temp(self):
+        unit_code = self.coordinator.data.get("temperature_unit", 1)
+        return 104 if unit_code == 0 else 40
 
     @property
     def hvac_mode(self):

--- a/custom_components/new_bestway_spa/number.py
+++ b/custom_components/new_bestway_spa/number.py
@@ -1,7 +1,11 @@
+from homeassistant.const import UnitOfTemperature
 from homeassistant.components.number import NumberEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 import asyncio
+
+C_TEMPS = {"min":20, "max":40}
+F_TEMPS = {"min":68, "max":104}
 
 async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
@@ -19,10 +23,8 @@ class BestwaySpaTargetTemperature(CoordinatorEntity, NumberEntity):
         self._attr_name = f"{title} Target Temperature"
         self._attr_unique_id = f"{device_id}_temperature_setting"
         self._device_id = device_id
-        self._attr_native_min_value = 20.0
-        self._attr_native_max_value = 40.0
+        self._attr_device_class = "temperature"
         self._attr_native_step = 0.5
-        self._attr_native_unit_of_measurement = "°C"
 
     @property
     def device_info(self):
@@ -37,6 +39,21 @@ class BestwaySpaTargetTemperature(CoordinatorEntity, NumberEntity):
     @property
     def native_value(self):
         return self.coordinator.data.get("temperature_setting")
+
+    @property
+    def native_unit_of_measurement(self):
+        unit_code = self.coordinator.data.get("temperature_unit", 1)
+        return UnitOfTemperature.FAHRENHEIT if unit_code == 0 else UnitOfTemperature.CELSIUS
+
+    @property
+    def native_min_value(self):
+        unit_code = self.coordinator.data.get("temperature_unit", 1)
+        return F_TEMPS["min"] if unit_code == 0 else C_TEMPS["min"]
+    
+    @property
+    def native_max_value(self):
+        unit_code = self.coordinator.data.get("temperature_unit", 1)
+        return F_TEMPS["max"] if unit_code == 0 else C_TEMPS["max"]
 
     async def async_set_native_value(self, value: float):
         await self._api.set_state("temperature_setting", value)

--- a/custom_components/new_bestway_spa/sensor.py
+++ b/custom_components/new_bestway_spa/sensor.py
@@ -1,20 +1,21 @@
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from datetime import datetime, date
 from .const import DOMAIN
 
 SENSOR_TYPES = [
-    ("water_temperature", "Water Temperature", "°C"),
-    ("is_online", "Connection Status", None),
-    ("temperature_unit", "Temperature Unit", None),
-    ("warning", "Warning", None),
-    ("error_code", "Error Code", None),
-    ("hydrojet_state", "Hydrojet", None),
-    ("connect_type", "Connection Type", None),
-    ("wifi_version", "WiFi Version", None),
-    ("ota_status", "OTA Status", None),
-    ("mcu_version", "MCU Version", None),
-    ("trd_version", "TRD Version", None)
+    ("water_temperature", "Water Temperature"),
+    ("is_online", "Connection Status"),
+    ("temperature_unit", "Temperature Unit"),
+    ("warning", "Warning"),
+    ("error_code", "Error Code"),
+    ("hydrojet_state", "Hydrojet"),
+    ("connect_type", "Connection Type"),
+    ("wifi_version", "WiFi Version"),
+    ("ota_status", "OTA Status"),
+    ("mcu_version", "MCU Version"),
+    ("trd_version", "TRD Version")
 ]
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -22,8 +23,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = data["coordinator"]
     device_id = entry.title.lower().replace(' ', '_')
     sensors = [
-        BestwaySpaSensor(coordinator, key, name, unit, entry.title, device_id)
-        for key, name, unit in SENSOR_TYPES
+        BestwaySpaSensor(coordinator, key, name, entry.title, device_id)
+        for key, name in SENSOR_TYPES
     ]
     sensors.extend([
         DaysSinceSensor(coordinator, entry, "Filter", "filter_last_change", device_id),
@@ -32,13 +33,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(sensors)
 
 class BestwaySpaSensor(CoordinatorEntity, SensorEntity):
-    def __init__(self, coordinator, key, name, unit, title, device_id):
+    def __init__(self, coordinator, key, name, title, device_id):
         super().__init__(coordinator)
         self._key = key
         self._attr_name = f"{title} {name}"
         self._attr_unique_id = f"{device_id}_{key}"
         self._device_id = device_id
-        self._attr_native_unit_of_measurement = unit
 
         # enable long-term statistics for water temperature
         if self._key == "water_temperature":
@@ -59,15 +59,15 @@ class BestwaySpaSensor(CoordinatorEntity, SensorEntity):
     def native_value(self):
         if self._key == "temperature_unit":
             raw = self.coordinator.data.get("temperature_unit", 1)
-            return "°F" if raw == 0 else "°C" 
+            return UnitOfTemperature.FAHRENHEIT if raw == 0 else UnitOfTemperature.CELSIUS
         return self.coordinator.data.get(self._key)
 
     @property
     def native_unit_of_measurement(self):
         if self._key == "water_temperature":
             unit_code = self.coordinator.data.get("temperature_unit", 1)
-            return "°F" if unit_code == 0 else "°C"
-        return self._attr_native_unit_of_measurement
+            return UnitOfTemperature.FAHRENHEIT if unit_code == 0 else UnitOfTemperature.CELSIUS
+        return None
 
 class DaysSinceSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator, entry, name, key, device_id):
@@ -77,7 +77,7 @@ class DaysSinceSensor(CoordinatorEntity, SensorEntity):
         self._key = key
         self._device_id = device_id
         self._attr_unique_id = f"{device_id}_{key}_days_since"
-        self._attr_native_unit_of_measurement = "days"
+        self._attr_native_unit_of_measurement = UnitOfTime.DAYS
         self._attr_device_class = "duration"
         self._attr_state_class = "total_increasing"
 


### PR DESCRIPTION
- Use core temperature unit enums
- Infer the "native" temperature unit from the API response, and allow Home Assistant to handle the translations to user preferred unit.